### PR TITLE
UI: Ancho completo en Usuarios, Mis Entradas y Explorar

### DIFF
--- a/src/modules/events/presentation/pages/Events.page.tsx
+++ b/src/modules/events/presentation/pages/Events.page.tsx
@@ -98,7 +98,7 @@ export function EventsPage() {
 
   return (
     <div className="min-h-screen bg-gradient-to-br from-gray-50/80 to-blue-50/80 backdrop-blur-sm p-6">
-      <div className="max-w-7xl mx-auto">
+      <div className="w-full">
         {/* Header */}
         <div className="bg-gradient-to-br from-white to-indigo-100/98 backdrop-blur-lg shadow-xl border border-white/20 rounded-2xl p-6 mb-8">
           <div className="flex items-center space-x-4">

--- a/src/modules/payments/presentation/pages/Tickets.page.tsx
+++ b/src/modules/payments/presentation/pages/Tickets.page.tsx
@@ -43,7 +43,7 @@ export function TicketsPage() {
 
   return (
     <div className="min-h-screen bg-gradient-to-br from-gray-50/80 to-blue-50/80 backdrop-blur-sm p-6">
-      <div className="max-w-7xl mx-auto">
+      <div className="w-full">
         {/* Header */}
         <div className="bg-gradient-to-br from-white to-indigo-100/98 backdrop-blur-lg shadow-xl border border-white/20 rounded-2xl p-6 mb-8">
           <div className="flex items-center justify-between">

--- a/src/modules/users/presentation/pages/Profile.page.tsx
+++ b/src/modules/users/presentation/pages/Profile.page.tsx
@@ -79,7 +79,7 @@ export function ProfilePage() {
 
   return (
     <div className="min-h-screen bg-gradient-to-br from-gray-50/80 to-blue-50/80 backdrop-blur-sm p-3 sm:p-4 md:p-6">
-      <div className="max-w-6xl mx-auto">
+      <div className="w-full">
         {/* Header Section */}
         <div className="mb-4 sm:mb-6 md:mb-8">
           <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between space-y-4 sm:space-y-0">

--- a/src/shared/ui/layouts/Footer.layout.tsx
+++ b/src/shared/ui/layouts/Footer.layout.tsx
@@ -4,7 +4,7 @@ import { Link } from 'react-router-dom';
 export function Footer() {
   return (
     <footer className="bg-gray-900 text-white">
-      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-16">
+      <div className="w-full px-4 sm:px-6 lg:px-8 py-16">
         <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-8">
           {/* Brand Section */}
           <div className="space-y-4">

--- a/src/shared/ui/layouts/Header.layout.tsx
+++ b/src/shared/ui/layouts/Header.layout.tsx
@@ -24,18 +24,16 @@ export function Header() {
 
   return (
     <header className="bg-gradient-to-r from-purple-600/90 via-purple-600/90 to-blue-500/90 backdrop-blur-md shadow-xl border-b border-white/20 fixed top-0 left-0 right-0 z-50">
-      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+      <div className="w-full px-4 sm:px-6 lg:px-8">
         <div className="flex justify-between items-center h-20">
           {/* Logo */}
-          <div className="flex items-center">
-            <Link to="/" className="flex items-center space-x-2 group">
-              <div className="w-10 h-10 bg-white/20 backdrop-blur-sm rounded-xl flex items-center justify-center shadow-lg border border-white/30 transform group-hover:scale-105 transition-transform duration-200">
-                <Calendar className="w-6 h-6 text-white" />
-              </div>
-              <span className="text-2xl font-bold text-white">
-                EventHub
-              </span>
-            </Link>
+          <div className="flex items-center space-x-2">
+            <div className="w-10 h-10 bg-white/20 backdrop-blur-sm rounded-xl flex items-center justify-center shadow-lg border border-white/30">
+              <Calendar className="w-6 h-6 text-white" />
+            </div>
+            <span className="text-2xl font-bold text-white">
+              EventHub
+            </span>
           </div>
 
           {/* Desktop Navigation */}


### PR DESCRIPTION
El módulo de usuarios, la página de “Mis Entradas” y la de “Explorar” ahora ocupan todo el ancho de pantalla en desktop (se eliminó el contenedor centrado con max-w-* y se reemplazó por w-full).
El Header y el Footer también se ajustaron para ser full-width en desktop.
El ícono y el título “EventHub” en el header ya no tienen acción de clic ni redirigen al inicio; ahora son solo elementos visuales.

closes #65 