### PR TITLE
Solucion de el error generado por el test CREAR EVENTOS

### DIFF
--- a/src/tests/unit/HU4-crear-eventos.test.ts
+++ b/src/tests/unit/HU4-crear-eventos.test.ts
@@ -252,7 +252,7 @@ describe('HU4: Crear eventos', () => {
 
   it('CA9: debe aceptar fechas futuras', () => {
     // Arrange
-    const futureDate = new Date('2025-12-31T20:00:00');
+    const futureDate = new Date('2026-12-31T20:00:00');
     const currentDate = new Date();
 
     // Act & Assert


### PR DESCRIPTION
## 🐛 Fix: Actualizar fecha en test de creación de eventos

### Descripción
Corregido el test `CA9: debe aceptar fechas futuras` en el archivo de pruebas de creación de eventos que estaba fallando.

### Cambios realizados
- Actualizada la fecha de prueba en `HU4-crear-eventos.test.ts` de `2025-12-31` a `2026-12-31`
- El test fallaba porque la fecha hardcodeada del 2025 ya es pasado (estamos en enero 2026)

### Archivos modificados
- `src/tests/unit/HU4-crear-eventos.test.ts`

### Tests
✅ Todos los tests pasan correctamente (356/356)